### PR TITLE
Fixed some consistency issues.

### DIFF
--- a/wintersmith-nap.coffee
+++ b/wintersmith-nap.coffee
@@ -17,7 +17,7 @@ module.exports = (env, callback) ->
   preview = 'preview' == process.argv[2]
 
   napCfg.mode      = if preview then 'development' else 'production'
-  napCfg.publicDir = if preview then roots.contents else '/build'
+  napCfg.publicDir = if preview then roots.contents else roots.output
 
   nap napCfg
 


### PR DESCRIPTION
- Get the root URLs from the configuration. The defaults will be automatically provided by WinterSmith if not present in `config.json`.
- Removed some unnecessary whitespace / indentation in the file.
- Used roots.output in production.

A special note here is that the defaults provided by the old code were using strings such as `/contents` which resolve to the root directory on UNIX operating systems. It is expected to use `./contents` and `./build` - which are the defaults provided by WinterSmith anyway.
