### PR TITLE
Simplified the process by removing `createNapWrapper`.

### DIFF
--- a/wintersmith-nap.coffee
+++ b/wintersmith-nap.coffee
@@ -21,20 +21,8 @@ module.exports = (env, callback) ->
 
   nap napCfg
 
-  if preview # development
-    createNapWrapper = (ext) ->
-      (section) ->
-        nap[ext](section).replace(/\/assets\/contents\//g, '/')
-
-    global.nap = {}
-    global.nap.css = createNapWrapper 'css'
-    global.nap.js = createNapWrapper 'js'
-    global.nap.jst = createNapWrapper 'jst'
-
-  else # production
-    nap.package()
-    global.nap = nap
-
+  nap.package() unless preview
+  global.nap = nap
 
   # we're done
   callback()


### PR DESCRIPTION
Maybe I'm missing something here, but it doesn't seem like this is used at all after a bit of testing.  So, I refactored the process to not use it. If it is used, a comment might be helpful to explain what case it is used for?
